### PR TITLE
Fixed RoomTests and Room's addItem method

### DIFF
--- a/DungeonSource/dungeon/Room.java
+++ b/DungeonSource/dungeon/Room.java
@@ -131,15 +131,24 @@ public class Room implements Serializable {
 	
 	public boolean addItem(Item I)
 	{
+		if (this.isEntrance() || this.isExit())
+			return false;
+		else if (this.getItem() instanceof Pillar)
+			return false;
+		else if (this.getNumItems() > 0 && I instanceof Pillar)
+			return false;
+		
 		Iterator <Item> itemIterator = items.iterator();
 		while(itemIterator.hasNext())
 		{
-			String nextType = itemIterator.next().type;
-			if(nextType.equals(I.type) || itemIterator.next() instanceof Pillar)
-				{
-					return false;
-				}
+			Item nextItem = itemIterator.next();
+			String nextType = nextItem.type;
+			if(nextType.equals(I.type))
+			{
+				return false;
+			}
 		}
+		
 		items.add(I);
 		return true;
 	}

--- a/DungeonSource/dungeon/tests/RoomTests.java
+++ b/DungeonSource/dungeon/tests/RoomTests.java
@@ -22,10 +22,11 @@ class RoomTests {
 			}
 		}
 		
+		//Rooms are room[row][column]
 		roomUpperLeft = rooms[0][0];
 		roomBottomRight = rooms[4][4];
-		roomLeftSide = rooms[0][1];
-		roomRightSide = rooms[4][2];
+		roomLeftSide = rooms[1][0];
+		roomRightSide = rooms[1][4];
 		roomCenter = rooms[2][2];
 	}
 	
@@ -193,6 +194,32 @@ class RoomTests {
 		
 		assertTrue(roomCenter.getNumItems() == 0);
 		assertTrue(roomCenter.getMonster() == null);
+	}
+	
+	@Test
+	void testAddItem() {
+		Room r = new Room(0,0);
+		r.addItem(new Potion(r));
+		assertTrue(r.getItem() instanceof Potion);
+		
+		r = new Room(0,0);
+		r.addItem(new Pillar(r));
+		assertTrue(r.getItem() instanceof Pillar);
+		
+		r = new Room(0,0);
+		r.addItem(new Pit(r));
+		assertTrue(r.getItem() instanceof Pit);
+		
+		assertFalse(r.addItem(new Pillar(r))); //Shouldnt add new pillar to room with items
+		assertFalse(r.addItem(new Pit(r))); //Shouldn't be able to add same item twice
+		
+		//Shouldnt be able to add items to exits and entrances
+		r = new Room(0,0);
+		r.setEntrance();
+		assertFalse(r.addItem(new Potion(r)));
+		r= new Room(0,0);
+		r.setExit();
+		assertFalse(r.addItem(new Potion(r)));
 	}
 
 }


### PR DESCRIPTION
Fixed RoomTests to match the new x/y ordering. 
Added to the addItem method. addItem will not add items to rooms that are entrances/exits/have a pillar. Also will not add a pillar to a room with other items in it.