### PR TITLE
Fixes choice input bug in DungeonAdventure

### DIFF
--- a/DungeonSource/dungeon/DungeonAdventure.java
+++ b/DungeonSource/dungeon/DungeonAdventure.java
@@ -96,8 +96,7 @@ public class DungeonAdventure
 			System.out.println("New game?");
 			System.out.println("1: New game");
 		}
-		int choice = kb.nextInt();
-	    System.out.flush();
+		int choice = Integer.parseInt(kb.nextLine());
 	    
 	    if(choice == 2 && saveFilesExist()) {
 			DungeonAdventure.loadGame(dungeon, theHero);


### PR DESCRIPTION
When loading a game, choice Scanner buffer is carried over to movement input, but changing how choice is parsed fixes that bug.